### PR TITLE
Add name-match support in sbuffer-defgroups

### DIFF
--- a/sbuffer.el
+++ b/sbuffer.el
@@ -435,6 +435,8 @@ NAME, okay, `checkdoc'?"
                             `(sbuffer-not ,name ,group))
                  (mode-match (name regexp)
                              `(sbuffer-group 'mode-match ,name ,regexp))
+                 (name-match (name regexp)
+                             `(sbuffer-group 'name-match ,name ,regexp))
                  (dir (dirs &optional depth)
                       `(sbuffer-group 'dir ,dirs ,depth))
                  (auto-directory () `(sbuffer-group 'auto-directory))


### PR DESCRIPTION
I know that is a work in progress but, in case of, I just added the name-match macro extension into sbuffer-defgroups